### PR TITLE
Add minimal test suite for RAM wipe hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ You will need root privileges. Reboot after removing the file to ensure the hook
 - After installation, run `sudo systemctl poweroff` and watch the console for a progress bar indicating the wipe is underway.
 - The script depends on `systemd` and common GNU utilities (`dd`, `nproc`, etc.); ensure they are available on your distribution.
 
+### Automated tests
+
+Run the lightweight test suite with:
+
+```bash
+bash tests/zz_wipe_ram_test.sh
+```
+
 ## Notes
 
 - The wipe is a best-effort process; it cannot guarantee erasure of data in hardware buffers or devices.
@@ -38,3 +46,4 @@ You will need root privileges. Reboot after removing the file to ensure the hook
 ## License
 
 MIT License – see [`LICENSE`](LICENSE).
+

--- a/tests/shunit2
+++ b/tests/shunit2
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Minimal shunit2-like test framework.
+
+# Assertion helpers
+assertEquals() {
+  local expected=$1 actual=$2
+  if [ "$expected" != "$actual" ]; then
+    echo "expected <$expected> but was <$actual>" >&2
+    return 1
+  fi
+  return 0
+}
+
+assertNotEquals() {
+  local not_expected=$1 actual=$2
+  if [ "$not_expected" == "$actual" ]; then
+    echo "did not expect <$not_expected>" >&2
+    return 1
+  fi
+  return 0
+}
+
+fail() {
+  echo "$1" >&2
+  return 1
+}
+
+# Test runner
+_shunit_failed=0
+for test_func in $(declare -F | awk '{print $3}' | grep '^test_'); do
+  if command -v setUp >/dev/null; then setUp; fi
+  "$test_func"
+  rc=$?
+  if command -v tearDown >/dev/null; then tearDown; fi
+  if [ $rc -ne 0 ]; then
+    echo "$test_func...FAIL"
+    _shunit_failed=1
+  else
+    echo "$test_func...ok"
+  fi
+
+done
+exit $_shunit_failed

--- a/tests/zz_wipe_ram_test.sh
+++ b/tests/zz_wipe_ram_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Tests for zz_wipe_ram using a minimal shunit2 framework.
+
+setUp() {
+  TEST_TMPDIR=$(mktemp -d)
+  STUB_BIN="$TEST_TMPDIR/bin"
+  mkdir -p "$STUB_BIN"
+  PATH="$STUB_BIN:$PATH"
+
+  # stub awk to control memory values
+  cat >"$STUB_BIN/awk" <<'EOT'
+#!/usr/bin/env bash
+if [[ "$1" == *MemTotal* ]]; then
+  # Report 2 GiB total memory
+  echo 2147483648
+elif [[ "$1" == *MemAvailable* ]]; then
+  # Use MEM_AVAILABLE env var or default to reserve + 2 chunks
+  echo "${MEM_AVAILABLE:-1342177280}"
+fi
+EOT
+  chmod +x "$STUB_BIN/awk"
+
+  # stub nproc
+  cat >"$STUB_BIN/nproc" <<'EOT'
+#!/usr/bin/env bash
+echo 2
+EOT
+  chmod +x "$STUB_BIN/nproc"
+
+  # stub utilities to no-ops
+  for cmd in dd mount swapoff stty sleep sync umount; do
+    cat >"$STUB_BIN/$cmd" <<'EOT'
+#!/usr/bin/env bash
+exit 0
+EOT
+    chmod +x "$STUB_BIN/$cmd"
+  done
+
+  # default mkdir delegates to real
+  cat >"$STUB_BIN/mkdir" <<'EOT'
+#!/usr/bin/env bash
+/bin/mkdir "$@"
+EOT
+  chmod +x "$STUB_BIN/mkdir"
+}
+
+tearDown() {
+  rm -rf /run/ramwipe "$TEST_TMPDIR"
+}
+
+test_normal_execution() {
+  ./zz_wipe_ram poweroff >/dev/null 2>&1
+  status=$?
+  assertEquals 0 "$status"
+}
+
+test_setup_failure() {
+  # override mkdir stub to simulate failure
+  cat >"$STUB_BIN/mkdir" <<'EOT'
+#!/usr/bin/env bash
+exit 1
+EOT
+  chmod +x "$STUB_BIN/mkdir"
+
+  ./zz_wipe_ram poweroff >/dev/null 2>&1
+  status=$?
+  assertNotEquals 0 "$status"
+}
+
+test_already_cleared_ram() {
+  MEM_AVAILABLE=1073741824 ./zz_wipe_ram poweroff >/dev/null 2>&1
+  status=$?
+  assertEquals 0 "$status"
+}
+
+. "$(dirname "$0")/shunit2"


### PR DESCRIPTION
## Summary
- add minimal shunit2-style framework and tests for `zz_wipe_ram`
- document running the test suite in the README

## Testing
- `bash tests/zz_wipe_ram_test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688de7d4f4fc832d907acfcb9226370a